### PR TITLE
Fix: Stop making assumption that bundle might start with 'define('

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,18 +49,15 @@ class MicroservicesWebpackPlugin {
 	async tapAsync(compilation, callback) {
     this.modules = await this.createUrlsToModules(this.modules);
 
+    const { libraryTarget } = compilation.runtimeTemplate.outputOptions;
+
 		compilation.assets = fromEntries(Object.entries(compilation.assets)
       .map(([fileName, asset]) => {
-        if (!fileName.includes('.js')) {
+        if (!fileName.includes('.js') || libraryTarget !== 'amd') {
           return [fileName, asset];
         }
 
         const source = asset.source();
-        const supportAmdOnly = 'define(';
-
-        if (!source.startsWith(supportAmdOnly)) {
-          return [fileName, asset];
-        }
 
         const value = [
           this.modules


### PR DESCRIPTION
Bundle might start with comment, like this:
```javascript
/* Hello, I broke your plugin */
define(
```